### PR TITLE
CRYP-17 ScenarioData 초기화버튼 기능 구현

### DIFF
--- a/src/components/Gnb/RecalculateButton.jsx
+++ b/src/components/Gnb/RecalculateButton.jsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import restore from 'assets/restore.png';
+import { useResetRecoilState } from 'recoil';
+import scenarioDataAtom from 'recoils/atoms/scenarioDataAtom';
 import { navButtonStyle } from './navButtonStyle';
 
 const buttonStyle = css`
@@ -28,8 +30,10 @@ const textStyle = css`
 `;
 
 const RecalculateButton = () => {
+  const resetScenarioData = useResetRecoilState(scenarioDataAtom);
+
   return (
-    <button type="button" css={[navButtonStyle, buttonStyle]}>
+    <button type="button" onClick={resetScenarioData} css={[navButtonStyle, buttonStyle]}>
       <img css={imgStyle} src={restore} alt="Restore" />
       <div css={textStyle}>다시 계산하기</div>
     </button>


### PR DESCRIPTION
## 변경 사항
ScenarioData 초기화버튼 기능 구현

## 작업 내용
Gnb 내의 RecalculateButton을 누르면 useResetRecoil(ScenarioDataAtom) 리셋 세터 핸들러가 동작하게 했습니다.

## 변경 사항 확인 방법
ScenarioDataAtom값을 변경한 후 RecalculateButton을 클릭하면 확인할 수 있습니다.

## 기타 사항
추후에 리코일을 쓸 때 렌더링이 언제 되는지 확인해야할 것 같습니다. 버튼을 눌러도 현재는 Atom 값을 쓰고 있지는 않기 때문에 Nav가 다시 렌더링 되지는 않습니다.
