### PR TITLE
CRYP-96 환율 상수 추가

### DIFF
--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -13,6 +13,6 @@ export const LOCALE_CURRENCY = Object.freeze({
   },
 });
 
-export const exchangeRate = Object.freeze({
+export const EXCHANGE_RATE = Object.freeze({
   KRWTOUSD: 0.001,
 });

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -12,3 +12,7 @@ export const LOCALE_CURRENCY = Object.freeze({
     currencySign: '$',
   },
 });
+
+export const exchangeRate = Object.freeze({
+  KRWTOUSD: 0.001,
+});


### PR DESCRIPTION
## 변경 사항
환율 상수를 추가했습니다.

## 작업 내용
utils/constants에 EXCHANGE_RATE라는 객체 상수와 KRWTOUSD: 0.001 이라는 프로퍼티 추가

## 변경 사항 확인 방법
import EXCHANGE_RATE from utils/constants로 불러와서
EXCHANGE_RATE[KRWTOUSD] 형식으로 사용하면 됩니다.
USDTOKRW은 나누기를 활용하면 됩니다.

## 기타 사항
임시로 0.001 값으로 정해놨고 추후에 실제 환율 정보를 받아와서 쓸 수도 있을 것 같습니다.
팀 컨벤션으로 api나 정적인 값을 저장할 때 모든 기본 단위는 KRW로 쓰기로 정했습니다.
