### PR TITLE
CRYP-120 정렬 버튼 이미지 토글 추가, 버튼 범위 변경

### DIFF
--- a/src/components/CryptoMarketCap/CryptoMarketCapList.jsx
+++ b/src/components/CryptoMarketCap/CryptoMarketCapList.jsx
@@ -4,7 +4,8 @@ import useFormattedPrice from 'hooks/useFormattedPrice';
 import PropTypes from 'prop-types';
 import orderNone from 'assets/order-none.svg';
 import orderAscending from 'assets/order-ascending.svg';
-// import orderDesending from 'assets/order-desending.svg';
+import orderDesending from 'assets/order-desending.svg';
+import { useEffect, useState } from 'react';
 import PriceChangeChip from './PriceChangeChip';
 
 const listStyle = css`
@@ -88,55 +89,120 @@ const imageStyle = css`
 
 const CryptoMarketCapList = ({ cryptoList, clickHandlers, order }) => {
   const formatPrice = useFormattedPrice(true);
+  const [srcList, setSrcList] = useState([
+    orderAscending,
+    orderNone,
+    orderNone,
+    orderNone,
+    orderNone,
+    orderNone,
+    orderNone,
+    orderNone,
+  ]);
+
+  useEffect(() => {
+    const updatedSrcList = [];
+
+    if (order === 'marketCapRank') {
+      updatedSrcList.push(orderAscending);
+    } else {
+      updatedSrcList.push(order === 'marketCapRankAscend' ? orderDesending : orderNone);
+    }
+
+    if (order === 'name') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'nameAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'currentPrice') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'currentPriceAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'marketCap') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'marketCapAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'totalVolume') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'totalVolumeAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'pc1h') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'pc1hAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'pc24h') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'pc24hAscend' ? orderAscending : orderNone);
+    }
+
+    if (order === 'pc7d') {
+      updatedSrcList.push(orderDesending);
+    } else {
+      updatedSrcList.push(order === 'pc7dAscend' ? orderAscending : orderNone);
+    }
+
+    setSrcList(updatedSrcList);
+  }, [order]);
+
   return (
     <ul css={listStyle}>
       <li css={headerStyle}>
         <div css={headerItemStyle}>
-          #
           <button type="button" onClick={clickHandlers.marketCapRankSort} css={buttonStyle}>
-            <img src={orderAscending} alt="Ascending Order" />
+            #
+            <img src={srcList[0]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          화폐 이름
           <button type="button" onClick={clickHandlers.nameSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            화폐 이름
+            <img src={srcList[1]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          가격
           <button type="button" onClick={clickHandlers.currentPriceSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            가격
+            <img src={srcList[2]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          총 시가
           <button type="button" onClick={clickHandlers.marketCapSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            총 시가
+            <img src={srcList[3]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          24시간 거래량
           <button type="button" onClick={clickHandlers.totalVolumeSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            24시간 거래량
+            <img src={srcList[4]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          1시간 변동폭
           <button type="button" onClick={clickHandlers.pc1hSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            1시간 변동폭
+            <img src={srcList[5]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          24시간 변동폭
           <button type="button" onClick={clickHandlers.pc24hSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            24시간 변동폭
+            <img src={srcList[6]} alt="Order" />
           </button>
         </div>
         <div css={headerItemStyle}>
-          7일 변동폭
           <button type="button" onClick={clickHandlers.pc7dSort} css={buttonStyle}>
-            <img src={orderNone} alt="None Order" />
+            7일 변동폭
+            <img src={srcList[7]} alt="Order" />
           </button>
         </div>
       </li>

--- a/src/components/CryptoMarketCap/CryptoMarketCapList.jsx
+++ b/src/components/CryptoMarketCap/CryptoMarketCapList.jsx
@@ -93,7 +93,7 @@ const CryptoMarketCapList = ({ cryptoList, clickHandlers, order }) => {
       <li css={headerStyle}>
         <div css={headerItemStyle}>
           #
-          <button type="button" onClick={clickHandlers.marketCapSort} css={buttonStyle}>
+          <button type="button" onClick={clickHandlers.marketCapRankSort} css={buttonStyle}>
             <img src={orderAscending} alt="Ascending Order" />
           </button>
         </div>

--- a/src/components/CryptoMarketCap/index.jsx
+++ b/src/components/CryptoMarketCap/index.jsx
@@ -21,7 +21,7 @@ const bodyStyle = css`
 `;
 
 const CryptoMarketCap = () => {
-  const [order, setOrder] = useState('');
+  const [order, setOrder] = useState('marketCapRank');
   const [cryptoList, setCryptoList] = useState([]);
 
   const sortedCryptoList = cryptoList.sort((a, b) => {

--- a/src/components/CryptoMarketCap/index.jsx
+++ b/src/components/CryptoMarketCap/index.jsx
@@ -21,7 +21,7 @@ const bodyStyle = css`
 `;
 
 const CryptoMarketCap = () => {
-  const [order, setOrder] = useState('marketCap');
+  const [order, setOrder] = useState('');
   const [cryptoList, setCryptoList] = useState([]);
 
   const sortedCryptoList = cryptoList.sort((a, b) => {
@@ -31,6 +31,10 @@ const CryptoMarketCap = () => {
     if (orderVal.endsWith('Ascend')) {
       orderVal = orderVal.slice(0, -'Ascend'.length);
       isAscending = true;
+    }
+
+    if (orderVal.endsWith('Rank')) {
+      orderVal = orderVal.slice(0, -'Rank'.length);
     }
 
     const valueA = a[orderVal];
@@ -54,10 +58,10 @@ const CryptoMarketCap = () => {
 
   const clickHandlers = {
     marketCapRankSort: () => {
-      if (order === 'marketCapAscend') {
-        setOrder('marketCapAscend');
+      if (order === 'marketCapRank') {
+        setOrder('marketCapRankAscend');
       } else {
-        setOrder('marketCap');
+        setOrder('marketCapRank');
       }
     },
     nameSort: () => {


### PR DESCRIPTION
## 변경 사항
버튼 범위를 글자까지 확장했습니다.

## 작업 내용
정렬 버튼이 order의 state 값이 바뀔 때마다 srcList 배열 state를 변경하여 이미지 src가 토글되게 수정했습니다.

## 변경 사항 확인 방법
정렬 버튼 8개를 눌러서 이미지를 토글할 수 있습니다.

## 기타 사항
후에 order svg 파일을 하나만 쓰고 svg 속성을 바꾸는 식으로 변경하여 assets size를 줄이고자 합니다. (triangle svg도 그렇게 할 수 있을 것 같습니다.)
