### PR TITLE
CRYP-126-search-history-popup-mobile-design

### DIFF
--- a/src/components/Gnb/SearchHistoryPopup.jsx
+++ b/src/components/Gnb/SearchHistoryPopup.jsx
@@ -107,7 +107,7 @@ const historyItemStyle = css`
 @media (max-width: 767px) {
   gap: 0.4rem 1.2rem;
   padding: 1.6rem 2rem;
-  height: 9.1rem;
+  height: 9.2rem;
 
   & > *:nth-of-type(3) {
     width: auto;


### PR DESCRIPTION
## 변경 사항
모바일 페이지에서 검색 기록 텍스트가 overflow 되는 문제를 해결했습니다.

## 작업 내용
components/Gnb/SearchHistoryPopup.jsx
mobile 사이즈의 historyItemStyle에 height 0.1rem 추가했습니다.

## 변경 사항 확인 방법
모바일 사이즈로 검색 기록을 클릭하여 확인할 수 있습니다.
