### PR TITLE
CRYP-123 localstorage와 searchHistoryAtom 동기화

### DIFF
--- a/src/components/Gnb/SearchHistoryPopup.jsx
+++ b/src/components/Gnb/SearchHistoryPopup.jsx
@@ -166,9 +166,14 @@ const decrementStyle = css`
 
 const SearchHistoryPopup = ({ setShowPopup }) => {
   const searchHistory = useRecoilValue(searchHistoryAtom);
-  const resetSearchHistory = useResetRecoilState(searchHistoryAtom);
-  const formatPrice = useFormattedPrice();
+  const resetSearchHistoryAtom = useResetRecoilState(searchHistoryAtom);
   const setScenarioData = useSetRecoilState(scenarioDataAtom);
+  const formatPrice = useFormattedPrice();
+
+  const resetSearchHistory = () => {
+    resetSearchHistoryAtom();
+    localStorage.removeItem('searchHistory');
+  };
 
   const recalculateHistory = (item) => {
     setScenarioData(item);

--- a/src/hooks/useAtomStorageSync.jsx
+++ b/src/hooks/useAtomStorageSync.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import searchHistoryAtom from 'recoils/searchHistory/searchHistoryAtom';
+
+const useAtomStorageSync = () => {
+  const [searchHistory, setSearchHistory] = useRecoilState(searchHistoryAtom);
+
+  useEffect(() => {
+    const storedSearchHistory = localStorage.getItem('searchHistory');
+    if (storedSearchHistory !== null && searchHistory.length === 0) {
+      // localStorage에 저장된 searchHistory를 비어있는 Atom에 저장
+      setSearchHistory(JSON.parse(storedSearchHistory));
+    } else {
+      // Atom 값을 localStorage에 저장
+      localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
+    }
+  }, [searchHistory, setSearchHistory]);
+};
+
+export default useAtomStorageSync;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,8 +3,11 @@ import CoinDetails from 'components/CoinDetails';
 import CoinScenarioForm from 'components/CoinScenarioForm';
 import CryptoMarketCap from 'components/CryptoMarketCap';
 import Gnb from 'components/Gnb';
+import useAtomStorageSync from 'hooks/useAtomStorageSync';
 
 const HomePage = () => {
+  useAtomStorageSync();
+
   return (
     <>
       <Gnb />

--- a/src/recoils/searchHistory/searchHistoryAtom.jsx
+++ b/src/recoils/searchHistory/searchHistoryAtom.jsx
@@ -3,132 +3,133 @@ import { atom } from 'recoil';
 const searchHistoryAtom = atom({
   key: 'searchHistory',
   // 더미 데이터
-  default: [{
-    id: 1,
-    input: {
-      date: { year: 2022, month: 10, day: 12 },
-      price: 100000,
-      cryptoId: 'usd-coin',
-      image: 'https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1668148656',
+  default: [
+    {
+      id: 1,
+      input: {
+        date: { year: 2022, month: 10, day: 12 },
+        price: 100000,
+        cryptoId: 'usd-coin',
+        image: 'https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1668148656',
+      },
+      output: {
+        outputPrice: 5000000,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 19 },
+      },
     },
-    output: {
-      outputPrice: 5000000,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 19 },
+    {
+      id: 2,
+      input: {
+        date: { year: 2023, month: 11, day: 1 },
+        price: 100000,
+        cryptoId: 'dogecoin',
+        image: 'https://assets.coingecko.com/coins/images/5/large/dogecoin.png?1547792256',
+      },
+      output: {
+        outputPrice: 50000,
+        isSkyrocketed: false,
+        outputDate: { year: 2023, month: 4, day: 15 },
+      },
     },
-  },
-  {
-    id: 2,
-    input: {
-      date: { year: 2023, month: 11, day: 1 },
-      price: 100000,
-      cryptoId: 'dogecoin',
-      image: 'https://assets.coingecko.com/coins/images/5/large/dogecoin.png?1547792256',
+    {
+      id: 3,
+      input: {
+        date: { year: 2021, month: 3, day: 22 },
+        price: 5000,
+        cryptoId: 'bitcoin',
+        image: 'https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579',
+      },
+      output: {
+        outputPrice: 32150000,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 25 },
+      },
     },
-    output: {
-      outputPrice: 50000,
-      isSkyrocketed: false,
-      outputDate: { year: 2023, month: 4, day: 15 },
+    {
+      id: 4,
+      input: {
+        date: { year: 2019, month: 12, day: 25 },
+        price: 15300,
+        cryptoId: 'staked-ether',
+        image: 'https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1608607546',
+      },
+      output: {
+        outputPrice: 1285900,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 3, day: 21 },
+      },
     },
-  },
-  {
-    id: 3,
-    input: {
-      date: { year: 2021, month: 3, day: 22 },
-      price: 5000,
-      cryptoId: 'bitcoin',
-      image: 'https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579',
+    {
+      id: 5,
+      input: {
+        date: { year: 2019, month: 12, day: 25 },
+        price: 2000,
+        cryptoId: 'ethereum-classic',
+        image: 'https://assets.coingecko.com/coins/images/453/large/ethereum-classic-logo.png?1547034169',
+      },
+      output: {
+        outputPrice: 35000,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 18 },
+      },
     },
-    output: {
-      outputPrice: 32150000,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 25 },
+    {
+      id: 6,
+      input: {
+        date: { year: 2019, month: 12, day: 25 },
+        price: 2000,
+        cryptoId: 'internet-computer',
+        image: 'https://assets.coingecko.com/coins/images/14495/large/Internet_Computer_logo.png?1620703073',
+      },
+      output: {
+        outputPrice: 6946.73,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 15 },
+      },
     },
-  },
-  {
-    id: 4,
-    input: {
-      date: { year: 2019, month: 12, day: 25 },
-      price: 15300,
-      cryptoId: 'staked-ether',
-      image: 'https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1608607546',
+    {
+      id: 7,
+      input: {
+        date: { year: 2022, month: 12, day: 10 },
+        price: 200000,
+        cryptoId: 'true-usd',
+        image: 'https://assets.coingecko.com/coins/images/3449/large/tusd.png?1618395665',
+      },
+      output: {
+        outputPrice: 1336222.87,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 13 },
+      },
     },
-    output: {
-      outputPrice: 1285900,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 3, day: 21 },
+    {
+      id: 8,
+      input: {
+        date: { year: 2019, month: 12, day: 25 },
+        price: 202200,
+        cryptoId: 'crypto-com-chain',
+        image: 'https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1669699773',
+      },
+      output: {
+        outputPrice: 100230,
+        isSkyrocketed: false,
+        outputDate: { year: 2023, month: 4, day: 15 },
+      },
     },
-  },
-  {
-    id: 5,
-    input: {
-      date: { year: 2019, month: 12, day: 25 },
-      price: 2000,
-      cryptoId: 'ethereum-classic',
-      image: 'https://assets.coingecko.com/coins/images/453/large/ethereum-classic-logo.png?1547034169',
-    },
-    output: {
-      outputPrice: 35000,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 18 },
-    },
-  },
-  {
-    id: 6,
-    input: {
-      date: { year: 2019, month: 12, day: 25 },
-      price: 2000,
-      cryptoId: 'internet-computer',
-      image: 'https://assets.coingecko.com/coins/images/14495/large/Internet_Computer_logo.png?1620703073',
-    },
-    output: {
-      outputPrice: 6946.73,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 15 },
-    },
-  },
-  {
-    id: 7,
-    input: {
-      date: { year: 2022, month: 12, day: 10 },
-      price: 200000,
-      cryptoId: 'true-usd',
-      image: 'https://assets.coingecko.com/coins/images/3449/large/tusd.png?1618395665',
-    },
-    output: {
-      outputPrice: 1336222.87,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 13 },
-    },
-  },
-  {
-    id: 8,
-    input: {
-      date: { year: 2019, month: 12, day: 25 },
-      price: 202200,
-      cryptoId: 'crypto-com-chain',
-      image: 'https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1669699773',
-    },
-    output: {
-      outputPrice: 100230,
-      isSkyrocketed: false,
-      outputDate: { year: 2023, month: 4, day: 15 },
-    },
-  },
-  {
-    id: 9,
-    input: {
-      date: { year: 2018, month: 12, day: 10 },
-      price: 2000,
-      cryptoId: 'ethereum',
-      image: 'https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880',
-    },
-    output: {
-      outputPrice: 1213336222.87,
-      isSkyrocketed: true,
-      outputDate: { year: 2023, month: 5, day: 20 },
-    },
-  }],
+    {
+      id: 9,
+      input: {
+        date: { year: 2018, month: 12, day: 10 },
+        price: 2000,
+        cryptoId: 'ethereum',
+        image: 'https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880',
+      },
+      output: {
+        outputPrice: 1213336222.87,
+        isSkyrocketed: true,
+        outputDate: { year: 2023, month: 5, day: 20 },
+      },
+    }],
 });
 
 export default searchHistoryAtom;


### PR DESCRIPTION
## 변경 사항
기록 지우기 버튼 클릭 시 localstorage의 'searchHistory'도 초기화

## 작업 내용
1. localstorage의 'searchHistory' item과 searchHistoryAtom을 동기화하는 useAtomStorageSync() 커스텀 훅 작성
2. Atom을 사용하는 최상단 컴포넌트(HomePage.jsx)에 useAtomStorageSync() 호출

## 변경 사항 확인 방법
1. 크롬 개발 도구 Application -> localStorage 탭에서 'searchHistory' item을 확인할 수 있습니다.
2. npx vite(npm run dev)를 한 이후 searchHistoryAtom을 변경하고 저장해보면 localStorage는 변경되지 않고 localStorage에 있는 값이 Atom에 전달됨을 확인할 수 있습니다.
3. 검색 기록 팝업 후 기록 지우기 버튼을 클릭하면 Atom과 localstorage의 'searchHistory' item이 초기화됩니다. (Atom의 default값이 더미 데이터가 있으므로 확인하려면 default 값을 빈 배열로 바꿔서 확인해야 합니다.)

## 기타 사항
localStorage 용량 문제가 발생했을 때 생길 수 있는 문제를 처리해야할 수도 있습니다.
