### PR TITLE
CRYP-135 calendar 스타일링 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^4.29.7",
         "@tanstack/react-query-devtools": "^4.29.7",
         "@vitejs/plugin-react": "^4.0.0",
+        "date-fns": "^2.30.0",
         "moment": "^2.29.4",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^4.29.7",
     "@tanstack/react-query-devtools": "^4.29.7",
     "@vitejs/plugin-react": "^4.0.0",
+    "date-fns": "^2.30.0",
     "moment": "^2.29.4",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/components/CoinScenarioForm/DateInput.jsx
+++ b/src/components/CoinScenarioForm/DateInput.jsx
@@ -7,6 +7,7 @@ import useResponsiveView from 'hooks/useResponsiveView';
 /** @jsxImportSource @emotion/react */
 import whiteInvertedTriangleIcon from 'assets/white-inverted-triangle.svg';
 import invertedTriangleIcon from 'assets/inverted-triangle.svg';
+import ko from 'date-fns/locale/ko';
 import { coinScenarioInputStyle } from './coinScenarioInputStyle';
 
 const DateInput = ({ selectedDate, onSelectedDate }) => {
@@ -15,11 +16,7 @@ const DateInput = ({ selectedDate, onSelectedDate }) => {
     onSelectedDate(date);
   };
 
-  const filterPassedTime = (date) => {
-    const currentDate = new Date();
-    currentDate.setHours(0, 0, 0, 0);
-    return date <= currentDate;
-  };
+  console.log(selectedDate);
 
   return (
     <div css={coinScenarioInputStyle}>
@@ -30,7 +27,8 @@ const DateInput = ({ selectedDate, onSelectedDate }) => {
         placeholderText="년/월/일"
         dateFormat="yyyy년 MM월 dd일"
         shouldCloseOnSelect
-        filterDate={filterPassedTime}
+        maxDate={new Date()}
+        locale={ko}
       />
       <p>
         <img src={viewportType === 'Desktop' ? whiteInvertedTriangleIcon : invertedTriangleIcon} alt="Drop Down Triangle Icon" />

--- a/src/components/CoinScenarioForm/DateInput.jsx
+++ b/src/components/CoinScenarioForm/DateInput.jsx
@@ -15,6 +15,12 @@ const DateInput = ({ selectedDate, onSelectedDate }) => {
     onSelectedDate(date);
   };
 
+  const filterPassedTime = (date) => {
+    const currentDate = new Date();
+    currentDate.setHours(0, 0, 0, 0);
+    return date <= currentDate;
+  };
+
   return (
     <div css={coinScenarioInputStyle}>
       <DatePicker
@@ -24,6 +30,7 @@ const DateInput = ({ selectedDate, onSelectedDate }) => {
         placeholderText="년/월/일"
         dateFormat="yyyy년 MM월 dd일"
         shouldCloseOnSelect
+        filterDate={filterPassedTime}
       />
       <p>
         <img src={viewportType === 'Desktop' ? whiteInvertedTriangleIcon : invertedTriangleIcon} alt="Drop Down Triangle Icon" />

--- a/src/components/CoinScenarioForm/coinScenarioInputStyle.jsx
+++ b/src/components/CoinScenarioForm/coinScenarioInputStyle.jsx
@@ -12,8 +12,8 @@ export const coinScenarioInputStyle = css`
   border-radius: 1.2rem;
   background-color: var(--gray1);
 
-
   color: var(--white);
+
   &::placeholder {
       color: var(--gray4);
     }
@@ -28,6 +28,101 @@ export const coinScenarioInputStyle = css`
     margin:0;
 
   }
+
+  & .react-datepicker {
+    width: 30rem;
+    height: 35rem;
+    border-radius: 1rem;
+  }
+
+  & .react-datepicker__header {
+    width: 30rem !important;
+    font-size: 1.6rem;
+    border: none;
+    padding: 0;
+  }
+
+  & .react-datepicker__day {
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition-property: background-color; 
+    transition-duration: 2s; 
+  }
+
+  & .react-datepicker__day:hover {
+    background-color: var(--gray6);
+  }
+
+  & .react-datepicker__current-month {
+    font-size: 1.6rem;
+    background: var(--white);
+    padding: 2rem 0 1rem;
+    border-radius: 1rem;
+    font-weight: 500;
+  }
+
+  & .react-datepicker__month {
+    display: grid;
+    grid-template-rows: repeat(5, 1fr);
+    margin-top: 1rem;
+    font-size: 1.6rem;
+  }
+
+  & .react-datepicker__week {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    justify-items: center;
+    align-items: center;
+    height: 4rem;
+  }
+
+  & .react-datepicker__day--keyboard-selected {
+    background: transparent;
+    border: 1px solid black;
+    border-radius: 50%;
+  }
+
+  & .react-datepicker__navigation--previous {
+    top: 1.5rem;
+    left: 1rem;
+  }
+
+  & .react-datepicker__navigation--next {
+    top: 1.5rem;
+    right: 1rem;
+  }
+
+  & .react-datepicker__day--selected {
+    background: transparent;
+    border: 0.1rem solid 'var(--gray5)';
+    border-radius: 50%;
+    color: var(--black)
+  }
+
+  & .react-datepicker__day-names {
+    background: var(--white);
+    border: none;
+    display: grid;
+    text-align: center;
+    grid-template-columns: repeat(7, 1fr);
+    padding-top: 1rem;
+    align-items: center;
+    justify-items: center;
+    height: 5rem;
+  }
+
+  & .react-datepicker-popper {
+    z-index: 2
+  }
+
+  & .react-datepicker__triangle {
+    transform: translate3d(3rem, 0.1rem, 0) !important
+  }
+
+
   @media (max-width: 1199px){
     max-width : 100%;
     & .inputBox{

--- a/src/components/CoinScenarioForm/coinScenarioInputStyle.jsx
+++ b/src/components/CoinScenarioForm/coinScenarioInputStyle.jsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 export const coinScenarioInputStyle = css`
   position : relative;
 
-  & .inputBox{
+  & .inputBox {
   padding: 0 2.5rem;
   width: 100%;
   height: 7.4rem;


### PR DESCRIPTION
## 작업 내용
1. 캘린더에서 현재 날짜를 넘어가는 미래 날짜를 클릭할 수 없도록 설정했습니다.
2. 캘린더에서 현재 날짜는 bold 처리되며,  클릭한 요일은 동그라미, 캘린더에서 hover 된 요일은 색상 gray에 transition을 추가하였습니다.
3. 달력에 내용을 한글 패치 하기위해 라이브러리를 설치하였습니다.
