### PR TITLE
Cryp-47 CoinType 무한 스크롤링 구현

### DIFF
--- a/src/components/CoinScenarioForm/BottomSheet.jsx
+++ b/src/components/CoinScenarioForm/BottomSheet.jsx
@@ -36,13 +36,14 @@ const BottomSheet = ({
 }) => {
   const viewportType = useViewportType();
 
-  const heightLookup = {
-    Tablet: '56.5rem',
-    Mobile: '56.5rem',
-    SuperMobile: '47.2rem',
-  };
+  // const heightLookup = {
+  //   Tablet: '56.5rem',
+  //   Mobile: '56.5rem',
+  //   SuperMobile: '47.2rem',
+  // };
 
-  const bottomSheetHeight = heightLookup[viewportType];
+  // const bottomSheetHeight = heightLookup[viewportType];
+  const bottomSheetHeight = '100%';
 
   const handleBottomSheeOpen = () => {
     setIsBottomSheetOpen(true);

--- a/src/components/CoinScenarioForm/BottomSheet.jsx
+++ b/src/components/CoinScenarioForm/BottomSheet.jsx
@@ -36,14 +36,13 @@ const BottomSheet = ({
 }) => {
   const viewportType = useViewportType();
 
-  // const heightLookup = {
-  //   Tablet: '56.5rem',
-  //   Mobile: '56.5rem',
-  //   SuperMobile: '47.2rem',
-  // };
+  const heightLookup = {
+    Tablet: '56.5rem',
+    Mobile: '56.5rem',
+    SuperMobile: '47.2rem',
+  };
 
-  // const bottomSheetHeight = heightLookup[viewportType];
-  const bottomSheetHeight = '100%';
+  const bottomSheetHeight = heightLookup[viewportType];
 
   const handleBottomSheeOpen = () => {
     setIsBottomSheetOpen(true);

--- a/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
+++ b/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
@@ -214,8 +214,7 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
                           alt={coins.name}
                           className="coin-icon"
                         />
-                        {/* {coins.name} */}
-                        {coinIndex}
+                        {coins.name}
                       </button>
                     </li>
                   );

--- a/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
+++ b/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
@@ -85,7 +85,7 @@ const dropDownItemStyle = css`
     border-radius: 1.2rem;  
   }
 `;
-const fetchItems = async (pageParam = 1) => {
+const fetchItems = async ({ pageParam = 1 }) => {
   const response = await fetch(
     `${PRO_BASE_URL}/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=10&page=${pageParam}&sparkline=false&locale=en`,
     {
@@ -99,7 +99,7 @@ const fetchItems = async (pageParam = 1) => {
 
 const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
   const {
-    data, isLoading, isError, fetchNextPage, hasNextPage,
+    data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage,
   } = useInfiniteQuery(['coinsMarkets'], fetchItems, {
     getNextPageParam: (lastPage, allPages) => {
       return allPages.length < 100 && allPages.length + 1;
@@ -109,7 +109,6 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
     // retry: 1,
   });
 
-  console.log(data, hasNextPage);
   const viewportType = useResponsiveView();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -165,23 +164,30 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
       <div css={[dropDownBoxStyle, dropDownListContainerStyle]}>
         {isOpen && (
           <ul css={dropDownListStyle}>
-            {data.pages[0]
-                  && data.pages[0].map((item) => {
-                    return (
-                      <li
-                        key={item.id}
-                      >
-                        <button type="button" css={dropDownItemStyle} onClick={() => { return handleSelectCoin(item); }}>
-                          <img src={item.image} alt={item.name} className="coin-icon" />
-                          {item.name}
-                        </button>
-                      </li>
-                    );
-                  })}
+            {data.pages
+              && data.pages.map((page) => {
+                return page.map((coins) => {
+                  return (
+                    <li
+                      key={coins.id}
+                    >
+                      <button type="button" css={dropDownItemStyle} onClick={() => { return handleSelectCoin(coins); }}>
+                        <img src={coins.image} alt={coins.name} className="coin-icon" />
+                        {coins.name}
+                      </button>
+                    </li>
+                  );
+                });
+              })}
           </ul>
         )}
-      </div>
 
+      </div>
+      {hasNextPage && (
+        <button type="button" onClick={() => { return fetchNextPage(); }} disabled={isFetchingNextPage}>
+          {isFetchingNextPage ? 'Loading...' : 'Load more'}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
+++ b/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, {
+  useState, useEffect, useRef, useCallback,
+} from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import whiteInvertedTriangleIcon from 'assets/white-inverted-triangle.svg';
@@ -10,7 +12,6 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { coinScenarioInputStyle } from './coinScenarioInputStyle';
 
 const PRO_BASE_URL = import.meta.env.VITE_PRO_BASE_URL;
-const BASE_URL = import.meta.env.VITE_BASE_URL;
 const PRO_API_KEY = import.meta.env.VITE_X_CG_PRO_API_KEY;
 
 const dropDownBoxStyle = css`
@@ -87,7 +88,6 @@ const dropDownItemStyle = css`
 `;
 
 const fetchItems = async ({ pageParam = 1 }) => {
-  console.log(pageParam);
   const response = await fetch(
     `${PRO_BASE_URL}/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=10&page=${pageParam}&sparkline=false&locale=en`,
     {
@@ -102,8 +102,6 @@ const fetchItems = async ({ pageParam = 1 }) => {
 const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
   const {
     data,
-    isLoading,
-    isError,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -120,7 +118,6 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
   const lastItemRef = useRef(null);
-  console.log(lastItemRef);
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -151,12 +148,12 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
     onCoinSelect(data.pages[0][0]);
   }, [data, onCoinSelect]);
 
-  const handleIntersection = (entries) => {
+  const handleIntersection = useCallback((entries) => {
     const target = entries[0];
     if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(handleIntersection, {
@@ -170,7 +167,8 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
         observer.unobserve(lastItemRef.current);
       }
     };
-  }, [isOpen, lastItemRef.current, fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [isOpen, fetchNextPage,
+    hasNextPage, isFetchingNextPage, handleIntersection]);
 
   return (
     <div ref={dropdownRef} css={css`display:flex; flex-direction: column; gap: 0.4rem;`}>
@@ -202,8 +200,7 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
                   return (
                     <li
                       key={coins.id}
-                      // ref={isLastItem ? lastItemRef : null}
-                      ref={lastItemRef}
+                      ref={isLastItem ? lastItemRef : null}
                     >
                       <button
                         type="button"

--- a/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
+++ b/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
@@ -5,7 +5,6 @@ import React, {
 import { css } from '@emotion/react';
 import whiteInvertedTriangleIcon from 'assets/white-inverted-triangle.svg';
 import invertedTriangleIcon from 'assets/inverted-triangle.svg';
-// import useFetch from 'hooks/useFetch';
 import PropTypes from 'prop-types';
 import useResponsiveView from 'hooks/useResponsiveView';
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -109,9 +108,10 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
     getNextPageParam: (lastPage, allPages) => {
       return allPages.length + 1;
     },
-    // cacheTime: 5 * 60 * 1000,
-    // staleTime: 1 * 60 * 1000,
-    // retry: 1,
+    // 추후 변경
+    cacheTime: 5 * 60 * 1000,
+    staleTime: 1 * 60 * 1000,
+    retry: 1,
   });
 
   const viewportType = useResponsiveView();

--- a/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
+++ b/src/components/CoinScenarioForm/CoinTypeDropDown.jsx
@@ -192,9 +192,9 @@ const CoinTypeDropDown = ({ selectedCoin, onCoinSelect }) => {
       <div css={[dropDownBoxStyle, dropDownListContainerStyle]}>
         {isOpen && (
           <ul css={dropDownListStyle}>
-            {data.pages
-              && data.pages.map((page, pageIndex) => {
-                return page.map((coins, coinIndex) => {
+            {data?.pages
+              && data?.pages.map((page, pageIndex) => {
+                return page?.map((coins, coinIndex) => {
                   const isLastItem = pageIndex === data.pages.length - 1
                     && coinIndex === page.length - 1;
                   return (


### PR DESCRIPTION
## 변경 사항
CoinType의 무한 스크롤링을 구현했습니다.

## 작업 내용
- pro-key의 경우 header에 넣어 사용했습니다.
- IntersectionObserver를 사용해 스크롤마다 fetch해올 수 있도록 구현했습니다.

## 변경 사항 확인 방법
- ScenarioForm의 코인 선택 input을 클릭해 스크롤해보면 계속 값을 불러오는 것을 볼 수 있습니다.

## 기타 사항
- 로직과 관계없는 css의 공백 등이 수정되었어요. file-change 보실 때 참고해주세요!
- 검색 기능에 대해서 어떻게 할지 함께 고민해봐야합니다.
- deploy에서는 환경변수 설정을 안해서 데이터를 불러오지 못하기 때문에 안보이는 것 같습니다.